### PR TITLE
Add YouTube analytics Next.js app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/youtube-analytics-app/README.md
+++ b/youtube-analytics-app/README.md
@@ -1,0 +1,30 @@
+# YouTube Analytics App
+
+This is a minimal Next.js project that fetches basic statistics for a YouTube channel using the YouTube Data API.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+2. Set the `YOUTUBE_API_KEY` environment variable with your YouTube Data API key.
+
+3. Run the development server:
+
+```bash
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Features
+
+- Enter a YouTube channel ID and fetch statistics such as subscriber count and view count.
+- The API interaction is implemented in `utils/youtube.ts` and used from the index page.
+
+## Notes
+
+This repository does not include the `node_modules` directory. You must have network access to install the dependencies specified in `package.json`.

--- a/youtube-analytics-app/next-env.d.ts
+++ b/youtube-analytics-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/youtube-analytics-app/next.config.js
+++ b/youtube-analytics-app/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/youtube-analytics-app/package.json
+++ b/youtube-analytics-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "youtube-analytics-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5"
+  }
+}

--- a/youtube-analytics-app/pages/_app.tsx
+++ b/youtube-analytics-app/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/youtube-analytics-app/pages/api/channel.ts
+++ b/youtube-analytics-app/pages/api/channel.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fetchChannelStats } from '../../utils/youtube';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing channel id' });
+    return;
+  }
+
+  const data = await fetchChannelStats(id);
+  if (!data) {
+    res.status(500).json({ error: 'Failed to fetch data' });
+    return;
+  }
+  res.status(200).json(data);
+}

--- a/youtube-analytics-app/pages/index.tsx
+++ b/youtube-analytics-app/pages/index.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import styles from '../styles/Home.module.css';
+import { fetchChannelStats } from '../utils/youtube';
+
+export default function Home() {
+  const [channelId, setChannelId] = useState('');
+  const [stats, setStats] = useState<any | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!channelId) return;
+    const data = await fetchChannelStats(channelId);
+    setStats(data);
+  };
+
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>YouTube Analytics App</title>
+      </Head>
+      <main className={styles.main}>
+        <h1 className={styles.title}>YouTube Analytics</h1>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input
+            type="text"
+            value={channelId}
+            onChange={(e) => setChannelId(e.target.value)}
+            placeholder="Enter Channel ID"
+          />
+          <button type="submit">Fetch Stats</button>
+        </form>
+        {stats && (
+          <pre className={styles.output}>{JSON.stringify(stats, null, 2)}</pre>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/youtube-analytics-app/styles/Home.module.css
+++ b/youtube-analytics-app/styles/Home.module.css
@@ -1,0 +1,36 @@
+.container {
+  min-height: 100vh;
+  padding: 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.main {
+  padding: 5rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.title {
+  margin: 0;
+  line-height: 1.15;
+  font-size: 4rem;
+}
+
+.form {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.output {
+  margin-top: 2rem;
+  text-align: left;
+  white-space: pre-wrap;
+}

--- a/youtube-analytics-app/styles/globals.css
+++ b/youtube-analytics-app/styles/globals.css
@@ -1,0 +1,12 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/youtube-analytics-app/tsconfig.json
+++ b/youtube-analytics-app/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "@types/react"]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/youtube-analytics-app/utils/youtube.ts
+++ b/youtube-analytics-app/utils/youtube.ts
@@ -1,0 +1,26 @@
+/**
+ * Fetch basic statistics for a YouTube channel using the YouTube Data API.
+ * You must provide an API key via the YOUTUBE_API_KEY environment variable.
+ */
+export async function fetchChannelStats(channelId: string) {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey) {
+    console.warn('Missing YOUTUBE_API_KEY environment variable');
+    return null;
+  }
+
+  const url = `https://www.googleapis.com/youtube/v3/channels?part=statistics&id=${channelId}&key=${apiKey}`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error('Failed to fetch:', res.statusText);
+      return null;
+    }
+    const json = await res.json();
+    return json.items?.[0]?.statistics || null;
+  } catch (err) {
+    console.error('Request error', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- initialize basic Next.js project under `youtube-analytics-app`
- add simple page to fetch YouTube channel statistics
- provide API helper and API route
- document setup and usage
- ignore build and dependency directories

## Testing
- `git status --short`